### PR TITLE
Fix auth server so it can handle all requests

### DIFF
--- a/authserver/pom.xml
+++ b/authserver/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>1.2.2.RELEASE</version>
+		<version>1.2.6.RELEASE</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 


### PR DESCRIPTION
It need to protect:

1. /login and the OAuth UI
2. /oauth/token and friends (auth server)
3. others (e.g. /user) (resource server)

Each of those needs its own WebSecurityConfigurer. Spring Boot will
provide basic auth protection for 1, but we have added a form login
and hence need to explicitly protect that. 2 and 3 are handled by
Spring Security OAuth, but we need to configure them a bit (see
@EnableAuthorizationServer and @EnableResourceServer beans).

The global authentication manager (for users) is configured via
an @Autowired AuthenticationManagerBuilder. Spring Boot 1.2.6 is used
to ensure this works.